### PR TITLE
reflection: set `key_initialized` global to proper booleans

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -7144,7 +7144,7 @@ ZEND_METHOD(ReflectionReference, getId)
 			RETURN_THROWS();
 		}
 
-		REFLECTION_G(key_initialized) = 1;
+		REFLECTION_G(key_initialized) = true;
 	}
 
 	/* SHA1(ref || key) to avoid directly exposing memory addresses. */
@@ -8002,7 +8002,7 @@ PHP_MINIT_FUNCTION(reflection) /* {{{ */
 
 	reflection_property_hook_type_ptr = register_class_PropertyHookType();
 
-	REFLECTION_G(key_initialized) = 0;
+	REFLECTION_G(key_initialized) = false;
 
 	return SUCCESS;
 } /* }}} */


### PR DESCRIPTION
Instead of using `1` and `0`, use `true` and `false`