### PR TITLE
zend_language_parser.y: simplify `class_declaration_statement` grammar

### DIFF
--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -605,13 +605,10 @@ class_declaration_statement:
 		class_modifiers T_CLASS { $<num>$ = CG(zend_lineno); }
 		T_STRING extends_from implements_list backup_doc_comment '{' class_statement_list '}'
 			{ $$ = zend_ast_create_decl(ZEND_AST_CLASS, $1, $<num>3, $7, zend_ast_get_str($4), $5, $6, $9, NULL, NULL); }
-	|	T_CLASS { $<num>$ = CG(zend_lineno); }
-		T_STRING extends_from implements_list backup_doc_comment '{' class_statement_list '}'
-			{ $$ = zend_ast_create_decl(ZEND_AST_CLASS, 0, $<num>2, $6, zend_ast_get_str($3), $4, $5, $8, NULL, NULL); }
 ;
 
 class_modifiers:
-		class_modifier 					{ $$ = $1; }
+		%empty { $$ = 0; }
 	|	class_modifiers class_modifier
 			{ $$ = zend_add_class_modifier($1, $2); if (!$$) { YYERROR; } }
 ;


### PR DESCRIPTION
Allow `class_modifiers` to be empty (resulting in a `0`) and unify the rules for class declarations with and without modifiers.